### PR TITLE
add the shared lib '@ce/db' to devDepens bcz the the actual normal de…

### DIFF
--- a/apps/ce-client/package.json
+++ b/apps/ce-client/package.json
@@ -10,7 +10,6 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@ce/db": "workspace:*",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",
@@ -66,6 +65,7 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "@ce/db": "workspace:*",
     "@tailwindcss/typography": "^0.5.15",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
 
   apps/ce-client:
     dependencies:
-      '@ce/db':
-        specifier: workspace:*
-        version: link:../../packages/db
       '@hookform/resolvers':
         specifier: ^3.9.1
         version: 3.10.0(react-hook-form@7.62.0(react@18.3.1))
@@ -180,6 +177,9 @@ importers:
         specifier: ^3.4.0
         version: 3.5.3(zod@3.25.76)
     devDependencies:
+      '@ce/db':
+        specifier: workspace:*
+        version: link:../../packages/db
       '@tailwindcss/typography':
         specifier: ^0.5.15
         version: 0.5.16(tailwindcss@3.4.17)


### PR DESCRIPTION
add the shared lib '@ce/db' to devDependencies because the actual normal dependencies must be available publicly so the builder of the project can determine the dependencies while shipping the static code to prod